### PR TITLE
use MemPool instead of LRUCache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ os:
   - linux
   - osx
 julia:
-  - 0.5
   - 0.6
   - nightly
 notifications:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,7 +1,7 @@
-julia 0.5
+julia 0.6
 Thrift
 ProtoBuf
 Snappy
 Libz
-LRUCache
+MemPool
 Compat 0.17.0

--- a/src/Parquet.jl
+++ b/src/Parquet.jl
@@ -4,7 +4,7 @@ using Thrift
 using ProtoBuf
 using Snappy
 using Libz
-using LRUCache
+using MemPool
 using Compat
 
 import Base: show, open, close, values, start, next, done


### PR DESCRIPTION
This switches the page cache from LRUCache to MemPool.

Minimum required Julia version is also updated to v0.6, since MemPool is not available for a lower version.