### PR TITLE
replace `bytestring` with `String(copy(v))`

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Can inject the type dynamically to a module to have further methods working dire
 ````julia
 julia> schema(JuliaConverter(Main), p, :Customer)
 
-julia> Base.show(io::IO, cust::Customer) = println(io, bytestring(cust.c_name), " Phone#:", bytestring(cust.c_phone))
+julia> Base.show(io::IO, cust::Customer) = println(io, String(copy(cust.c_name)), " Phone#:", String(copy(cust.c_phone)))
 ````
 
 Create cursor to iterate over records. In parallel mode, multiple remote cursors can be created and iterated on in parallel.


### PR DESCRIPTION
* Version 0.5.2
```
WARNING: bytestring(v::Vector{UInt8}) is deprecated, use String(copy(v)) instead.
```

* Version 0.6.1
```
ERROR: LoadError: UndefVarError: bytestring not defined
```

ref: https://github.com/JuliaLang/julia/issues/16107#issuecomment-217519846